### PR TITLE
GET routes now populate owner w/ user information

### DIFF
--- a/app/routes/image_routes.js
+++ b/app/routes/image_routes.js
@@ -36,14 +36,14 @@ const router = express.Router()
 // INDEX
 // GET /images
 router.get('/images', requireToken, (req, res, next) => {
-  Image.find()
+  Image.find().populate('owner')
     .then(images => {
       // `images` will be an array of Mongoose documents
       // we want to convert each one to a POJO, so we use `.map` to
       // apply `.toObject` to each one
       return images.map(image => {
         const imageObj = image.toObject()
-        if (imageObj.owner == req.user.id) { // eslint-disable-line eqeqeq
+        if (imageObj.owner._id == req.user.id) { // eslint-disable-line eqeqeq
           imageObj.editable = true
         } else {
           imageObj.editable = false
@@ -61,11 +61,11 @@ router.get('/images', requireToken, (req, res, next) => {
 // GET /images/5a7db6c74d55bc51bdf39793
 router.get('/images/:id', requireToken, (req, res, next) => {
   // req.params.id will be set based on the `:id` in the route
-  Image.findById(req.params.id)
+  Image.findById(req.params.id).populate('owner')
     .then(handle404)
     .then(image => {
       const imageObj = image.toObject()
-      if (imageObj.owner == req.user.id) { // eslint-disable-line eqeqeq
+      if (imageObj.owner._id == req.user.id) { // eslint-disable-line eqeqeq
         imageObj.editable = true
       } else {
         imageObj.editable = false


### PR DESCRIPTION
+ index and show return an object where the owner is no longer an _id
+ owner is now the associated User object for these routes
+ NOTE: data returned from create and update are NOT populated and
must be dealt with client-side. Client already knows the signed-in user!

resolves Issue #19 